### PR TITLE
chore: Ignore T_ keys

### DIFF
--- a/gestureChart.ts
+++ b/gestureChart.ts
@@ -111,6 +111,10 @@ function generateTable(filteredKeys) : string {
       table += `#### Row ${row.id}\n`;
       table += newTableHeader();
       for (let k in row.key) {
+        if (row.key[k].id.startsWith('T_')) {
+          continue;
+        }
+
         // Print a new row
         table += ` | `;
 


### PR DESCRIPTION
Addresses this bullet point on keymanapp/keyman#11792

> Can cleanup console warnings about not handling T_ keys in the touch layout (not needed)